### PR TITLE
Slurm 18.08

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # slurm-debian
 
-First clone:
+To clone the submodules:
  * `git submodule update --init --recursive`
 
 To update the submodules:
-  * `git submodule foreach --recursive git pull`
+ * `git submodule foreach --recursive git pull`
 
-Build the debian package
- * cd slurm
- * git checkout slurm-17.11
- * ln -s ../debian .
- * dch -n (maybe w must upgrade the version number)
- * debian/rules build
- * fakeroot debian/rules binary
+Build the debian package:
+ * `cd slurm`
+ * `git checkout slurm-18.08`
+ * `ln -s ../debian .`
+ * `dch -n` (if you want to increase the version number)
+ * `debian/rules build`
+ * `fakeroot debian/rules binary`

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+slurm-llnl (18.08.1-1) stable; urgency=medium
+
+  * Update Slurm to 18.08.1.
+
+ -- Martijn Kruiten <martijn.kruiten@surfsara.nl>  Wed, 10 Oct 2018 13:52:09 +0200
+
 slurm-llnl (17.11.9-1) UNRELEASED; urgency=medium
 
   * Update Slurm to 17.11.9

--- a/debian/rules
+++ b/debian/rules
@@ -53,6 +53,9 @@ override_dh_auto_install:
 	# run make install for slurm-wlm-torque pkg
 	$(MAKE) -C obj-$(DEB_BUILD_GNU_TYPE)/contribs/torque install DESTDIR=$(CURDIR)/debian/tmp
 
+	# run make install for PMI pkg
+	$(MAKE) -C obj-$(DEB_BUILD_GNU_TYPE)/contribs/pmi install DESTDIR=$(CURDIR)/debian/tmp
+
 	# run make install for PMI2 pkg
 	$(MAKE) -C obj-$(DEB_BUILD_GNU_TYPE)/contribs/pmi2 install DESTDIR=$(CURDIR)/debian/tmp
 


### PR DESCRIPTION
- Slurm is updated to 18.08.1.
- PMI is moved to `contrib/pmi` upstream. `debian/rules` now reflects that change.